### PR TITLE
fix brightness mapping between bco and hass

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+### :scroll: Description
+
+Changes proposed in this pull request:
+* 
+
+### :hammer: Breaking Changes
+
+* 
+
+### :test_tube: Test Procedure
+
+* Start bco
+* Start hass device manager
+* Test
+
+### :white_check_mark: Checklist:
+
+- [ ] Created tests which fail without the change (if possible)
+- [ ] Extended the documentation (if necessary)
+
+### :camera_flash: Screenshots
+
+Screenshots to review the UX/UI Design:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,7 @@
 ### :scroll: Description
-
-Changes proposed in this pull request:
 * 
 
 ### :hammer: Breaking Changes
-
 * 
 
 ### :test_tube: Test Procedure
@@ -13,10 +10,7 @@ Changes proposed in this pull request:
 * Test
 
 ### :white_check_mark: Checklist:
-
 - [ ] Created tests which fail without the change (if possible)
 - [ ] Extended the documentation (if necessary)
 
 ### :camera_flash: Screenshots
-
-Screenshots to review the UX/UI Design:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,6 @@ Changes proposed in this pull request:
 * 
 
 ### :test_tube: Test Procedure
-
 * Start bco
 * Start hass device manager
 * Test

--- a/src/main/kotlin/org/openbase/bco/device/hass/manager/service/BrightnessStateServiceImpl.kt
+++ b/src/main/kotlin/org/openbase/bco/device/hass/manager/service/BrightnessStateServiceImpl.kt
@@ -8,6 +8,7 @@ import org.openbase.bco.device.hass.util.toHassBrightness
 import org.openbase.bco.device.hass.type.HassServiceType
 import org.openbase.bco.device.hass.util.isNotNull
 import org.openbase.bco.device.hass.util.isNull
+import org.openbase.bco.device.hass.util.toBCOBrightness
 import org.openbase.jul.exception.NotAvailableException
 import org.openbase.type.domotic.action.ActionDescriptionType.ActionDescription
 import org.openbase.type.domotic.state.BrightnessStateType.BrightnessState
@@ -55,6 +56,6 @@ class BrightnessStateServiceImpl<ST>(unit: ST) : HassService<ST>(unit),
 fun HassStateDto.isBrightnessState() = hue.isNull() && saturation.isNull() && brightness.isNotNull()
 
 fun HassStateDto.toBrightnessState(): BrightnessState.Builder = BrightnessState.newBuilder().apply {
-    brightness = this@toBrightnessState.brightness ?:
+    brightness = this@toBrightnessState.brightness?.toBCOBrightness() ?:
         throw NotAvailableException("Brightness is not available for entity[$entityId].")
 }

--- a/src/main/kotlin/org/openbase/bco/device/hass/util/HSBColorExtensions.kt
+++ b/src/main/kotlin/org/openbase/bco/device/hass/util/HSBColorExtensions.kt
@@ -8,6 +8,6 @@ fun Double.toHassSaturation(): Double = this * 100
 
 fun Double.toBCOSaturation(): Double = this / 100
 
-fun Double.toHassBrightness(): Double = this * 255 + 1
+fun Double.toHassBrightness(): Double = this * 255
 
-fun Double.toBCOBrightness(): Double = (this - 1) / 255
+fun Double.toBCOBrightness(): Double = (this / 255)

--- a/src/main/kotlin/org/openbase/bco/device/hass/util/HSBColorExtensions.kt
+++ b/src/main/kotlin/org/openbase/bco/device/hass/util/HSBColorExtensions.kt
@@ -10,4 +10,4 @@ fun Double.toBCOSaturation(): Double = this / 100
 
 fun Double.toHassBrightness(): Double = this * 255
 
-fun Double.toBCOBrightness(): Double = (this / 255)
+fun Double.toBCOBrightness(): Double = this / 255


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* fix brightness mapping by mapping the range [0-255] (observed) instead of [1-265] (documented) as incoming brightness value from home assistant.
* (additional) introduce PR template

### :test_tube: Test Procedure

* Start bco
* Start hass device manager
* Change a Light to 0.0 brightness via home assistant and verify that the value is 0.0 in BCO
* Change a Light to 1.0 brightness via home assistant and verify that the value is 1.0 in BCO